### PR TITLE
パンくずリストAPIの機能追加とサイトマップAPIの追加

### DIFF
--- a/api-document.yaml
+++ b/api-document.yaml
@@ -148,6 +148,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /breadcrumbs:
+    get:
+      tags:
+        - open
+      summary: "パンくずリスト取得API"
+      description: |-
+        パンくずリストの情報を取得します。
+        クエリパラメータでurlかpathを指定します。指定しない場合は、トップページのパンくずリストが帰ってきます。
+      parameters:
+        - in: "query"
+          name: "url"
+          schema:
+            type: string
+            format: uri
+        - in: "query"
+          name: "path"
+          schema:
+            type: string
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BreadcrumbsResponse'
+
 
   /login:
     post:
@@ -844,6 +870,12 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/Storage'
+    BreadcrumbsResponse:
+      type: object
+      properties:
+        data:
+          type: string
+          description: ''
 
     LoginRequest:
       type: object

--- a/api-document.yaml
+++ b/api-document.yaml
@@ -173,7 +173,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BreadcrumbsResponse'
-
+  /sitemap:
+    get:
+      tags:
+        - open
+      summary: "サイトマップ取得API"
+      description: |-
+        サイトマップの情報を取得します。
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SitemapResponse'
 
   /login:
     post:
@@ -876,6 +889,17 @@ components:
         data:
           type: string
           description: ''
+    SitemapResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: string
+          example:
+            - http://localhost:3000
+            - http://localhost:3000/pages/admin
+            - http://localhost:3000/pages/admin/storages/1581315433ra05d0
 
     LoginRequest:
       type: object

--- a/app/Http/Controllers/BreadcrumbsController.php
+++ b/app/Http/Controllers/BreadcrumbsController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use App\Services\BreadcrumbsService;
-use App\Http\Requests\BreadcrumbsFormRequest;
+use App\Http\Requests\BreadcrumbsRequest;
 
 class BreadcrumbsController extends Controller
 {
@@ -21,10 +21,10 @@ class BreadcrumbsController extends Controller
     /**
      * パンくずリストの生成
      *
-     * @param BreadcrumbsFormRequest $request
+     * @param \App\Http\Requests\BreadcrumbsRequest $request
      * @return void
      */
-    public function index(BreadcrumbsFormRequest $request)
+    public function index(BreadcrumbsRequest $request)
     {
         return $this->_service->render($request);
     }

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -18,9 +18,9 @@ class SitemapController extends Controller
     }
 
     /**
-     * @return JsonResponse
+     * @return mixed
      */
-    public function index(): JsonResponse
+    public function index()
     {
         return $this->_service->generate();
     }

--- a/app/Http/Requests/BreadcrumbsRequest.php
+++ b/app/Http/Requests/BreadcrumbsRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class BreadcrumbsFormRequest extends FormRequest
+class BreadcrumbsRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/BreadcrumbsRequest.php
+++ b/app/Http/Requests/BreadcrumbsRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\ClientUrl;
 use Illuminate\Foundation\Http\FormRequest;
 
 class BreadcrumbsRequest extends FormRequest
@@ -24,7 +25,8 @@ class BreadcrumbsRequest extends FormRequest
     public function rules()
     {
         return [
-            //
+            'path' => ['string', 'max:255'],
+            'url'  => ['string', 'url', new ClientUrl]
         ];
     }
 }

--- a/app/Http/Resources/Sitemap.php
+++ b/app/Http/Resources/Sitemap.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Sitemap extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Repositories/Storage/StorageRepository.php
+++ b/app/Repositories/Storage/StorageRepository.php
@@ -40,6 +40,15 @@ class StorageRepository implements StorageRepositoryInterface
         return $this->_storage->whereStorageId($storage_id)->delete();
     }
 
+    /**
+     * すべての作品を取得する
+     *
+     * @return mixed
+     */
+    public function get_all_storages_with_user()
+    {
+        return $this->_storage->with('user')->get()->all();
+    }
 
     /**
      * 全ユーザーの全作品を取得する

--- a/app/Repositories/Storage/StorageRepositoryInterface.php
+++ b/app/Repositories/Storage/StorageRepositoryInterface.php
@@ -23,6 +23,13 @@ interface StorageRepositoryInterface
     public function destroy_storage(string $storage_id): ?bool;
 
     /**
+     * すべての作品を取得する
+     *
+     * @return mixed
+     */
+    public function get_all_storages_with_user();
+
+    /**
      * 全ユーザーの全作品を取得する
      *
      * @param integer $per_page

--- a/app/Repositories/User/UserRepository.php
+++ b/app/Repositories/User/UserRepository.php
@@ -31,6 +31,17 @@ class UserRepository implements UserRepositoryInterface
     }
 
     /**
+     * プロフィールとともにすべてのユーザーを取得する
+     *
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function get_all_user_with_profile()
+    {
+        $user = $this->_user->with('user_profile')->get()->all();
+        return $user;
+    }
+
+    /**
      * 名前によってユーザーデータを取得する
      *
      * @param string $user_name

--- a/app/Repositories/User/UserRepositoryInterface.php
+++ b/app/Repositories/User/UserRepositoryInterface.php
@@ -16,6 +16,13 @@ interface UserRepositoryInterface
     public function delete_user(string $user_id): ?bool;
 
     /**
+     * プロフィールとともにすべてのユーザーを取得する
+     *
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function get_all_user_with_profile();
+
+    /**
      * 名前によってユーザーデータを取得する
      *
      * @param string $user_name

--- a/app/Rules/ClientUrl.php
+++ b/app/Rules/ClientUrl.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Rules;
+
+use App\Facades\Helper;
+use Illuminate\Contracts\Validation\Rule;
+
+class ClientUrl implements Rule
+{
+    /**
+     * 許可するURL
+     *
+     * @var string[]
+     */
+    protected $_allow_urls;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->_allow_urls = [
+            'http://localhost:3000'
+        ];
+        $client = Helper::client_route('/');
+        if (strcmp($this->_allow_urls[0], $client) !== 0) {
+            $this->_allow_urls[] = $client;
+        }
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (is_null($value)) {
+            return true;
+        }
+
+        return $this->check_url($value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The validation error message.';
+    }
+
+    /**
+     * 値が許可するURLに一致するか確認する
+     *
+     * @param string $value
+     * @return boolean
+     */
+    protected function check_url(string $value): bool
+    {
+        $allow_urls = $this->_allow_urls;
+        foreach ($allow_urls as $allow_url) {
+            if (strpos($value, $allow_url) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Services/BreadcrumbsService.php
+++ b/app/Services/BreadcrumbsService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-use Illuminate\Http\JsonResponse;
+use Exception;
 use App\Http\Requests\BreadcrumbsFormRequest;
 use DaveJamesMiller\Breadcrumbs\Facades\Breadcrumbs;
 use App\Http\Resources\Breadcrumbs as BreadcrumbsResource;
@@ -21,17 +21,73 @@ class BreadcrumbsService
      */
     public function render(BreadcrumbsFormRequest $request): BreadcrumbsResource
     {
-        // TODO: $request を使って、パンくずリストを生成。
-        $breadcrumbs_name = 'blog';
+        $path = $request->path;
 
         try {
-            return new BreadcrumbsResource(Breadcrumbs::generate($breadcrumbs_name));
+            $data = $this->get_breadcrumb_data($path);
+            if (is_null($data)) {
+                throw new Exception;
+            }
+
+            if (isset($data['data'])) {
+                return new BreadcrumbsResource(Breadcrumbs::generate($data['name'], $data['data']));
+            }
+
+            return new BreadcrumbsResource(Breadcrumbs::generate($data['name']));
         } catch (UnnamedRouteException $e) {
             // TODO:Exception that is thrown if the user attempt to render breadcrumbs for the current route but the current route doesn't have a name.を書く
             return abort(response()->json(['message' => $e->getMessage()], 500));
         } catch (InvalidBreadcrumbException $e) {
             // TODO: Exception that is thrown if the user attempts to generate breadcrumbs for a page that is not registered. を書く。
             return abort(response()->json(['message' => $e->getMessage()], 500));
+        } catch (Exception $e) {
+            return abort(response()->json(['message' => $e->getMessage()], 500));
         }
+    }
+
+    /**
+     * Breadcrumbs用のデータを作成する
+     *
+     * @param string $path
+     * @return array|null
+     */
+    protected function get_breadcrumb_data(string $path): ?array
+    {
+        $path = trim($path, '/');
+        $path_arr = explode("/", $path);
+        if ($path_arr === false) {
+            return null;
+        }
+        $path_arr_len = count($path_arr);
+
+        $ret_arr = [
+            'name' => null,
+            'data' => null
+        ];
+
+        // pages関連
+        if ($path_arr[0] === 'pages') {
+            $user = $path_arr[1];
+
+            if ($path_arr_len > 4) {
+                $storage_id = $path_arr[3];
+                $ret_arr['name'] = 'pages_storage_id';
+                $ret_arr['data'] = [
+                    'user'       => $user,
+                    'storage_id' => $storage_id
+                ];
+                return $ret_arr;
+            }
+
+            $ret_arr['name'] = 'pages_user';
+            $ret_arr['data'] = [
+                'user' => $user,
+            ];
+            return $ret_arr;
+        }
+
+        $ret_arr['name'] = $path_arr[0];
+
+        return $ret_arr;
     }
 }

--- a/app/Services/BreadcrumbsService.php
+++ b/app/Services/BreadcrumbsService.php
@@ -3,7 +3,7 @@
 namespace App\Services;
 
 use Exception;
-use App\Http\Requests\BreadcrumbsFormRequest;
+use App\Http\Requests\BreadcrumbsRequest;
 use DaveJamesMiller\Breadcrumbs\Facades\Breadcrumbs;
 use App\Http\Resources\Breadcrumbs as BreadcrumbsResource;
 use DaveJamesMiller\Breadcrumbs\Exceptions\InvalidBreadcrumbException;
@@ -14,12 +14,12 @@ class BreadcrumbsService
     /**
      * パンくずリストを生成する
      *
-     * @param BreadcrumbsFormRequest $request
+     * @param \App\Http\Requests\BreadcrumbsRequest $request
      * @return BreadcrumbsResource
      * @throws \DaveJamesMiller\Breadcrumbs\Exceptions\UnnamedRouteException
      * @throws \DaveJamesMiller\Breadcrumbs\Exceptions\InvalidBreadcrumbException
      */
-    public function render(BreadcrumbsFormRequest $request): BreadcrumbsResource
+    public function render(BreadcrumbsRequest $request): BreadcrumbsResource
     {
         $path = $request->path;
 

--- a/app/Services/SitemapService.php
+++ b/app/Services/SitemapService.php
@@ -2,12 +2,81 @@
 
 namespace App\Services;
 
+use App\Facades\Helper;
 use Illuminate\Http\JsonResponse;
+use App\Http\Resources\Sitemap as SitemapResource;
+use App\Repositories\User\UserRepositoryInterface;
+use App\Repositories\Storage\StorageRepositoryInterface;
 
 class SitemapService
 {
-    public function generate(): JsonResponse
+    /**
+     * @var \App\Repositories\User\UserRepositoryInterface
+     */
+    protected $_userRepository;
+
+    /**
+     * @var \App\Repositories\Storage\StorageRepositoryInterface
+     */
+    protected $_storageRepository;
+
+    public function __construct(UserRepositoryInterface $userRepository, StorageRepositoryInterface $storageRepository)
     {
-        return response()->json([]);
+        $this->_userRepository = $userRepository;
+        $this->_storageRepository = $storageRepository;
+    }
+
+    /**
+     * サイトマップの作成
+     *
+     * @return SitemapResource
+     */
+    public function generate(): SitemapResource
+    {
+        $urls = [$this->client_url('/')];
+        $urls = array_merge($urls, $this->generate_pages());
+        $urls = array_merge($urls, $this->generate_page_storages());
+        return new SitemapResource($urls);
+    }
+
+    /**
+     * フロントのURLを作成
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function client_url(string $path = '/'): string
+    {
+        return Helper::client_route($path);
+    }
+
+    /**
+     * /pages/{user}に関するurl一覧を作成
+     *
+     * @return array|null
+     */
+    protected function generate_pages(): ?array
+    {
+        $users = $this->_userRepository->get_all_user_with_profile();
+        $urls = [];
+        foreach ($users as $user) {
+            $urls[] = $this->client_url('pages/' . $user->name);
+        }
+        return $urls;
+    }
+
+    /**
+     * /pages/{user}/storages/{storage_id}に関するurl一覧を作成
+     *
+     * @return array|null
+     */
+    protected function generate_page_storages(): ?array
+    {
+        $storages = $this->_storageRepository->get_all_storages_with_user();
+        $urls = [];
+        foreach ($storages as $storage) {
+            $urls[] = $this->client_url('pages/' . $storage->user->name . '/storages' . '/' . $storage->storage_id);
+        }
+        return $urls;
     }
 }

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -7,8 +7,33 @@ Breadcrumbs::for('home', function ($trail) {
     $trail->push('Home', H::client_route('/'));
 });
 
-// Home > blog
-Breadcrumbs::for('blog', function ($trail) {
+// Home > [user]
+Breadcrumbs::for('pages_user', function ($trail, array $data) {
     $trail->parent('home');
-    $trail->push('Blog', H::client_route('/blog'));
+    $trail->push($data['user'], H::client_route('/pages' . '/' . $data['user']));
+});
+
+// Home > [user] > [storage_id]
+Breadcrumbs::for('pages_storage_id', function ($trail, array $data) {
+    $trail->parent('pages_user');
+    $path = '/pages' . '/' . $data['user'] . '/storages' . '/' . $data['storage_id'];
+    $trail->push($data['storage_id'], H::client_route($path));
+});
+
+// Home > login
+Breadcrumbs::for('login', function ($trail) {
+    $trail->parent('home');
+    $trail->push('Login', H::client_route('/login'));
+});
+
+// Home > register
+Breadcrumbs::for('register', function ($trail) {
+    $trail->parent('home');
+    $trail->push('Register', H::client_route('/register'));
+});
+
+// Home > sitemap
+Breadcrumbs::for('sitemap', function ($trail) {
+    $trail->parent('home');
+    $trail->push('Sitemap', H::client_route('/sitemap'));
 });

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -15,9 +15,9 @@ Breadcrumbs::for('pages_user', function ($trail, array $data) {
 
 // Home > [user] > [storage_id]
 Breadcrumbs::for('pages_storage_id', function ($trail, array $data) {
-    $trail->parent('pages_user');
-    $path = '/pages' . '/' . $data['user'] . '/storages' . '/' . $data['storage_id'];
-    $trail->push($data['storage_id'], H::client_route($path));
+    $trail->parent('pages_user', $data);
+    $path = '/pages' . '/' . $data['user'] . '/storages' . '/' . $data['storage']['storage_id'];
+    $trail->push($data['storage']['title'], H::client_route($path));
 });
 
 // Home > login


### PR DESCRIPTION
## やったこと
- パンくずリストのクエリーパラメータにurlに対応
- サイトマップの作成
- swaggerの更新