### PR TITLE
画像の保存、リサイズの処理を書き直した

### DIFF
--- a/app/Exceptions/FileSystem/FailedStoreFile.php
+++ b/app/Exceptions/FileSystem/FailedStoreFile.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions\FileSystem;
+
+use Exception;
+
+class FailedStoreFile extends Exception
+{
+    //
+}

--- a/app/Http/Resources/Util/Storage.php
+++ b/app/Http/Resources/Util/Storage.php
@@ -25,7 +25,7 @@ class Storage extends JsonResource
             "title"               => $this->title,
             "description"         => $this->description,
             "long_comment"        => $this->long_comment,
-            "storage_sub_image"   => StorageSubImageResource::collection($this->storage_sub_image),
+            "storage_sub_images"  => StorageSubImageResource::collection($this->storage_sub_image),
             "storage_file"        => StorageFileResource::collection($this->storage_file),
             "eyecatch_image_id"   => $this->eyecatch_image_id,
             "eyecatch_image"      => new ImageResource($this->eyecatch_image),

--- a/app/Http/Resources/Util/StorageSubImage.php
+++ b/app/Http/Resources/Util/StorageSubImage.php
@@ -15,8 +15,6 @@ class StorageSubImage extends Resource
      */
     public function toArray($request)
     {
-        return [
-            'image' => new ImageResource($this->image)
-        ];
+        return new ImageResource($this->image);
     }
 }

--- a/app/Repositories/Image/ImageRepository.php
+++ b/app/Repositories/Image/ImageRepository.php
@@ -21,4 +21,14 @@ class ImageRepository implements ImageRepositoryInterface
     {
         return $this->_image->create($inserts);
     }
+
+    public function updateOrCreate(array $inserts, string $id = null)
+    {
+        $attributes = [];
+        if (isset($id)) {
+            $attributes['id'] = $id;
+        }
+
+        return $this->_image->updateOrCreate($attributes, $inserts);
+    }
 }

--- a/app/Repositories/Image/ImageRepositoryInterface.php
+++ b/app/Repositories/Image/ImageRepositoryInterface.php
@@ -5,4 +5,6 @@ namespace App\Repositories\Image;
 interface ImageRepositoryInterface
 {
     public function create(array $inserts);
+
+    public function updateOrCreate(array $inserts, string $id = null);
 }

--- a/app/Repositories/Storage/StorageSubImageRepository.php
+++ b/app/Repositories/Storage/StorageSubImageRepository.php
@@ -25,7 +25,7 @@ class StorageSubImageRepository implements StorageSubImageRepositoryInterface
      * @param integer|null $id
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $inserts, int $storage_id, ?int $id = null)
+    public function updateOrCreate(array $inserts, int $storage_id, ?string $id = null)
     {
         $attributes = ['storage_id' => $storage_id];
         if (isset($id)) {

--- a/app/Repositories/Storage/StorageSubImageRepositoryInterface.php
+++ b/app/Repositories/Storage/StorageSubImageRepositoryInterface.php
@@ -12,5 +12,5 @@ interface StorageSubImageRepositoryInterface
      * @param integer $id
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $inserts, int $storage_id, ?int $id = null);
+    public function updateOrCreate(array $inserts, int $storage_id, ?string $id = null);
 }

--- a/app/Services/FileSystem/FileSystemService.php
+++ b/app/Services/FileSystem/FileSystemService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services\FileSystem;
+
+use Storage;
+
+class FileSystemService
+{
+    /**
+     * @var \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    public $_disk;
+
+    public $_localDisk;
+
+    public function __construct()
+    {
+        $default = config('filesystems.default');
+        $this->_disk = Storage::disk($default);
+        $this->_localDisk = Storage::disk('local');
+    }
+
+    /**
+     * 一時ファイルの作成
+     *
+     * @param mixed $file
+     * @return string
+     */
+    public function create_tmp($file): string
+    {
+        // ファイルを一時ファイルに保存
+        $filename_tmp = $file->store('/tmp', 'local');
+        $filename = trim($filename_tmp, 'tmp/');
+        return $filename;
+    }
+
+
+    /**
+     * pathをきれいにする
+     *
+     * @param string $path
+     * @return string
+     */
+    public function format_path(string $path): string
+    {
+        return '/'.trim($path, '/').'/';
+    }
+
+    /**
+     * 拡張子を取得する
+     *
+     * @param mixed $file
+     * @return string
+     */
+    public function get_extension($file): string
+    {
+        return strtolower($file->getClientOriginalExtension());
+    }
+}

--- a/app/Services/FileSystem/ImageService.php
+++ b/app/Services/FileSystem/ImageService.php
@@ -21,15 +21,15 @@ class ImageService
         $this->_imageRepository = $imageRepository;
     }
 
-    public function store($file, string $name, string $path)
+    public function store($file, string $name, string $path, string $image_id = null)
     {
         $urls = $this->store_image($file, $path);
         $inserts = $urls;
-        $inserts['id'] = Str::uuid();
+        $inserts['id'] = $image_id ?? Str::uuid();
         $inserts['title'] = $name;
         $inserts['extension'] = $this->_service->get_extension($file);
 
-        $imageModel = $this->_imageRepository->create($inserts);
+        $imageModel = $this->_imageRepository->updateOrCreate($inserts, $image_id);
         return $imageModel->id;
     }
 

--- a/app/Services/FileSystem/ImageService.php
+++ b/app/Services/FileSystem/ImageService.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Services\FileSystem;
+
+use App\Exceptions\FileSystem\FailedStoreFile;
+use App\Repositories\Image\ImageRepositoryInterface;
+use App\Services\FileSystem\FileSystemService;
+use Illuminate\Support\Str;
+use Intervention\Image\Facades\Image;
+use Intervention\Image\Image as ImageImage;
+
+class ImageService
+{
+    protected $_service;
+
+    protected $_imageRepository;
+
+    public function __construct(FileSystemService $service, ImageRepositoryInterface $imageRepository)
+    {
+        $this->_service = $service;
+        $this->_imageRepository = $imageRepository;
+    }
+
+    public function store($file, string $name, string $path)
+    {
+        $urls = $this->store_image($file, $path);
+        $inserts = $urls;
+        $inserts['id'] = Str::uuid();
+        $inserts['title'] = $name;
+        $inserts['extension'] = $this->_service->get_extension($file);
+
+        $imageModel = $this->_imageRepository->create($inserts);
+        return $imageModel->id;
+    }
+
+    /**
+     * 画像をファイルに保存
+     *
+     * @param mixed $file
+     * @param string $path
+     * @return array
+     */
+    public function store_image($file, string $path): array
+    {
+        $path = $this->_service->format_path($path);
+        $ext = $this->_service->get_extension($file);
+        $filename = $this->_service->create_tmp($file); // 一時ファイルの作成
+
+        $image = Image::make($file);
+
+        // オリジナル画像の保存
+        $original_url = $this->store_original_image($image, $path, $filename, $ext);
+
+        $sizes = [];
+        // 画像をまとめてリサイズする
+        $imageArr = $this->resizing_in_bulk($image, $ext, $sizes);
+
+        $urls = [];
+        $urls['url'] = $original_url;
+        // リサイズした画像を保存する
+        foreach ($imageArr as $_image) {
+            $_filename = $path.$_image->width().'-'.$filename;
+            $this->_service->_disk->put($_filename, (string)$_image);
+            $urls['url_'.$_image->width()] = $this->_service->_disk->url($_filename);
+        }
+
+        // 一時ファイルを削除
+        $this->_service->_localDisk->delete('tmp/'.$filename);
+
+        return $urls;
+    }
+
+    /**
+     * オリジナルの画像を保存する
+     *
+     * @param ImageImage $image
+     * @param string $path
+     * @param string $filename
+     * @param string $ext
+     * @return string
+     * @throws FailedStoreFile
+     */
+    public function store_original_image(ImageImage $image, string $path, string $filename, string $ext): string
+    {
+        $bool = $this->_service->_disk->put($path.$filename, (string)$image->encode($ext, 90));
+        if ($bool) {
+            return $this->_service->_disk->url($path.$filename);
+        }
+
+        throw new FailedStoreFile();
+    }
+
+    /**
+     * 画像をまとめてリサイズする
+     *
+     * @param ImageImage $image
+     * @param string $extension
+     * @param integer[] $sizes
+     * @param integer $quality
+     * @return ImageImage[]
+     */
+    public function resizing_in_bulk(ImageImage $image, string $extension, array $sizes, int $quality = 70): array
+    {
+        $retArr = [];
+        rsort($sizes); // 数値の大きい順にソート
+        // それぞれのサイズの画像を作成
+        foreach ($sizes as $size) {
+            if ($image->width() > $size) {
+                $retArr[] = $this->image_resize($image, $extension, $size, $quality);
+            }
+        }
+        return $retArr;
+    }
+
+    /**
+     * 画像のリサイズをする
+     *
+     * @param ImageImage $image
+     * @param string $extension
+     * @param integer $width
+     * @param integer $quality
+     * @return ImageImage
+     */
+    public function image_resize(ImageImage $image, string $extension, int $width, int $quality = 70): ImageImage
+    {
+        $image->orientate(); // 回転の補正
+        return $image->resize($width, null, function ($constraint) {
+            $constraint->upsize();
+            $constraint->aspectRatio();
+        })->encode($extension, $quality);
+    }
+}

--- a/app/Services/FileSystemService.php
+++ b/app/Services/FileSystemService.php
@@ -116,6 +116,43 @@ class FileSystemService
             // Modelに挿入
             $imageModel = $this->_imageRepository->create($inserts);
 
+            \Log::debug($imageModel);
+
+            // uuidを返す
+            return $imageModel->id;
+        }
+
+        $this->store_image_error($filename);
+    }
+
+    public function store_imageFile($file, string $image_name, string $path = ''): ?string
+    {
+        $path = '/'.trim($path, '/').'/';
+
+        // ファイルを一時ファイルに保存
+        $filename_tmp = $file->store('/tmp', 'local');
+        $filename = trim($filename_tmp, 'tmp/');
+
+        // 画像の拡張子を取得
+        $extension = $file->getClientOriginalExtension();
+
+        $img = Image::make($file);
+
+        // ファイルに追加
+        $inserts = $this->store_image($img, $path, $filename, $extension);
+        $inserts['id'] = Str::uuid();
+        $inserts['title'] = $image_name;
+
+        if (isset($inserts['url'])) {
+            // 一時ファイルを削除
+            $tmp_delete = $this->_localDisk->delete($filename_tmp);
+            if ($tmp_delete === false) {
+                throw new Exception();
+            }
+
+            // Modelに挿入
+            $imageModel = $this->_imageRepository->create($inserts);
+
             // uuidを返す
             return $imageModel->id;
         }

--- a/app/Services/Storages/StoreSubImageService.php
+++ b/app/Services/Storages/StoreSubImageService.php
@@ -25,7 +25,6 @@ class StoreSubImageService
     public function store(int $storage_id, $request)
     {
         $image_ids = [];
-        // foreach ($request->file('storage_sub_images') as $key => $step) {
         foreach ($request->file('storage_sub_images') as $file) {
             $image_id = $this->_service->store_imageFile($file, 'storage_sub_images', '/storages/sub_image/');
             $image_ids[] = $image_id;

--- a/app/Services/Storages/StoreSubImageService.php
+++ b/app/Services/Storages/StoreSubImageService.php
@@ -3,20 +3,20 @@
 namespace App\Services\Storages;
 
 use App\Repositories\Storage\StorageSubImageRepositoryInterface;
-use App\Services\FileSystemService;
+use App\Services\FileSystem\ImageService;
 
 class StoreSubImageService
 {
     protected $_storageSubImageRepository;
 
     /**
-     * @var \App\Services\FileSystemService
+     * @var \App\Services\FileSystem\ImageService
      */
     protected $_service;
 
     public function __construct(
         StorageSubImageRepositoryInterface $storageSubImageRepositoryInterface,
-        FileSystemService $service
+        ImageService $service
     ) {
         $this->_storageSubImageRepository = $storageSubImageRepositoryInterface;
         $this->_service = $service;
@@ -26,7 +26,7 @@ class StoreSubImageService
     {
         $image_ids = [];
         foreach ($request->file('storage_sub_images') as $file) {
-            $image_id = $this->_service->store_imageFile($file, 'storage_sub_images', '/storages/sub_image/');
+            $image_id = $this->_service->store($file, 'storage_sub_images', '/storages/sub_image/');
             $image_ids[] = $image_id;
         }
 

--- a/app/Services/Storages/StoreSubImageService.php
+++ b/app/Services/Storages/StoreSubImageService.php
@@ -25,8 +25,9 @@ class StoreSubImageService
     public function store(int $storage_id, $request)
     {
         $image_ids = [];
-        foreach ($request->file('storage_sub_images') as $key => $step) {
-            $image_id = $this->_service->store_imageFile($request->file('storage_sub_images')[$key], 'storage_sub_images.tmp.' . $key, '/storages/sub_image/');
+        // foreach ($request->file('storage_sub_images') as $key => $step) {
+        foreach ($request->file('storage_sub_images') as $file) {
+            $image_id = $this->_service->store_imageFile($file, 'storage_sub_images', '/storages/sub_image/');
             $image_ids[] = $image_id;
         }
 

--- a/app/Services/Storages/StoreSubImageService.php
+++ b/app/Services/Storages/StoreSubImageService.php
@@ -22,11 +22,11 @@ class StoreSubImageService
         $this->_service = $service;
     }
 
-    public function store(int $storage_id, array $files)
+    public function store(int $storage_id, $request)
     {
         $image_ids = [];
-        foreach ($files as $file) {
-            $image_id = $this->_service->store_requestImage($file, 'パース画像', '/storages/sub_image/');
+        foreach ($request->file('storage_sub_images') as $key => $step) {
+            $image_id = $this->_service->store_imageFile($request->file('storage_sub_images')[$key], 'storage_sub_images.tmp.' . $key, '/storages/sub_image/');
             $image_ids[] = $image_id;
         }
 
@@ -34,7 +34,8 @@ class StoreSubImageService
             $this->_storageSubImageRepository
                 ->updateOrCreate(
                     ['image_id' => $image_id, 'storage_id' => $storage_id],
-                    $storage_id
+                    $storage_id,
+                    $image_id
                 );
         }
     }

--- a/app/Services/Users/StorageService.php
+++ b/app/Services/Users/StorageService.php
@@ -154,11 +154,6 @@ class StorageService
             return response()->json(['message' => $e->getMessage()], 500);
         }
 
-        if (isset($request->storage_sub_images)) {
-            $this->_storeSubImageService->store($storage_id, $request->storage_sub_images);
-            $request_except[] = 'storage_sub_images';
-        }
-
         // DBに保存するデータの作成
         if (isset($request_except)) {
             $inserts = $request->except($request_except);
@@ -180,6 +175,9 @@ class StorageService
         $this->_fileSystemService
                             ->store_requestStorage($request, $storage->id, 'storage', '/storages/storage/');
 
+        if (isset($request->storage_sub_images)) {
+            $this->_storeSubImageService->store($storage->id, $request);
+        }
 
         return new StorageResource($storage);
     }

--- a/database/migrations/2020_02_09_082330_create_user_profiles_table.php
+++ b/database/migrations/2020_02_09_082330_create_user_profiles_table.php
@@ -16,6 +16,7 @@ class CreateUserProfilesTable extends Migration
         Schema::create('user_profiles', function (Blueprint $table) {
             $table->unsignedBigInteger('user_id');
             $table->string('nick_name', '30')->nullable()->comment('あだ名');
+            $table->string('kana', '30')->nullable()->comment('フリガナ');
             $table->string('job_name', '50')->nullable()->comment('肩書き');
             $table->string('hobby', '50')->nullable()->comment('趣味');
             $table->string('description', '50')->nullable()->comment('一言コメント');

--- a/database/migrations/2020_03_01_192434_create_images_table.php
+++ b/database/migrations/2020_03_01_192434_create_images_table.php
@@ -15,6 +15,7 @@ class CreateImagesTable extends Migration
     {
         Schema::create('images', function (Blueprint $table) {
             $table->uuid('id')->primary()->comment('image ID');
+            $table->string('extension', 30)->nullable()->comment('拡張子');
             $table->string('title', 255)->comment('画像名');
             $table->string('url', 255)->comment('オリジナル画像');
             $table->string('url_80', 255)->nullable()->comment('width = 80');

--- a/database/migrations/2020_03_20_235854_create_storage_files_table.php
+++ b/database/migrations/2020_03_20_235854_create_storage_files_table.php
@@ -15,7 +15,7 @@ class CreateStorageFilesTable extends Migration
     {
         Schema::create('storage_files', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('storage_id');
+            $table->unsignedBigInteger('storage_id')->index();
             $table->string('url', '255')->comment('URL');
             $table->string('extension', '50')->comment('拡張子');
             $table->softDeletes();

--- a/database/migrations/2020_03_20_235935_create_storage_sub_images_table.php
+++ b/database/migrations/2020_03_20_235935_create_storage_sub_images_table.php
@@ -15,7 +15,7 @@ class CreateStorageSubImagesTable extends Migration
     {
         Schema::create('storage_sub_images', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('storage_id');
+            $table->unsignedBigInteger('storage_id')->index();
             $table->uuid('image_id');
             $table->softDeletes();
             $table->timestamps();

--- a/database/migrations/2020_03_21_000940_create_user_careers_table.php
+++ b/database/migrations/2020_03_21_000940_create_user_careers_table.php
@@ -15,7 +15,7 @@ class CreateUserCareersTable extends Migration
     {
         Schema::create('user_careers', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('user_id');
+            $table->bigInteger('user_id')->index();
             $table->date('date')->comment('日付');
             $table->string('name', '100')->comment('名前');
             $table->softDeletes();


### PR DESCRIPTION
# やったこと
- dbのカラムの修正 (#41 )
- パース画像のcreateのみを対応(updateには非対応)
- resourceの修正

## あとで
あとで、もっときれいにする。